### PR TITLE
FEATURE: Support group messages

### DIFF
--- a/javascripts/discourse/initializers/layouts-groups.js.es6
+++ b/javascripts/discourse/initializers/layouts-groups.js.es6
@@ -1,3 +1,4 @@
+import { ajax } from 'discourse/lib/ajax';
 import { withPluginApi } from 'discourse/lib/plugin-api';
 
 export default {
@@ -37,6 +38,15 @@ export default {
       props['groups'] = groups;
     }
 
-    layouts.addSidebarProps(props);
+    props.groups.forEach((group) => {
+      ajax(`/groups/${group.name}.json`).then((result) => {
+        const groupAttrs = result.group;
+        group.groupAttrs = groupAttrs;
+
+        layouts.addSidebarProps(props);
+      });
+    });
+
+    console.log('initializer', props.groups);
   },
 };

--- a/javascripts/discourse/widgets/layouts-groups.js.es6
+++ b/javascripts/discourse/widgets/layouts-groups.js.es6
@@ -81,6 +81,12 @@ createWidget('layouts-group-link', {
   },
 
   click() {
-    DiscourseURL.routeTo(`/g/${this.attrs.name}/messages`);
+    if (group.is_group_user && group.has_messages) {
+      DiscourseURL.routeTo(`/g/${this.attrs.name}/messages`);
+    } else {
+      DiscourseURL.routeTo(`/g/${this.attrs.name}`);
+    }
   },
 });
+
+

--- a/javascripts/discourse/widgets/layouts-groups.js.es6
+++ b/javascripts/discourse/widgets/layouts-groups.js.es6
@@ -22,7 +22,7 @@ export default layouts.createLayoutsWidget('group-list', {
         'a.layouts-group-list-header',
         {
           attributes: {
-            href: '/groups',
+            href: '/g?type=my',
             title: I18n.t(themePrefix('groups_widget.title')),
           },
         },
@@ -81,6 +81,6 @@ createWidget('layouts-group-link', {
   },
 
   click() {
-    DiscourseURL.routeTo(`/groups/${this.attrs.name}`);
+    DiscourseURL.routeTo(`/g/${this.attrs.name}/messages`);
   },
 });

--- a/javascripts/discourse/widgets/layouts-groups.js.es6
+++ b/javascripts/discourse/widgets/layouts-groups.js.es6
@@ -70,6 +70,21 @@ createWidget('layouts-group-link', {
   tagName: 'li.layouts-group-link',
   buildKey: (attrs) => `layouts-group-link-${attrs.id}`,
 
+  buildAttributes() {
+    const { groupAttrs } = this.attrs;
+    let displayName = this.attrs.name;
+
+    if (groupAttrs && groupAttrs.full_name) {
+      displayName = groupAttrs.full_name;
+    }
+
+    const attributes = {
+      title: displayName,
+    };
+
+    return attributes;
+  },
+
   getGroupTitle(group) {
     return h('span.group-title', group.name);
   },

--- a/javascripts/discourse/widgets/layouts-groups.js.es6
+++ b/javascripts/discourse/widgets/layouts-groups.js.es6
@@ -1,5 +1,4 @@
 import { iconNode } from 'discourse-common/lib/icon-library';
-import { ajax } from 'discourse/lib/ajax';
 import DiscourseURL from 'discourse/lib/url';
 import { createWidget } from 'discourse/widgets/widget';
 import { h } from 'virtual-dom';
@@ -58,14 +57,9 @@ export default layouts.createLayoutsWidget('group-list', {
 
     groups.forEach((group) => {
       if (!hiddenGroups.includes(group.id.toString())) {
-        ajax(`/groups/${group.name}.json`).then((result) => {
-          const groupAttrs = result.group;
-          group.groupAttrs = groupAttrs;
-        });
         groupItems.push(this.attach('layouts-group-link', group));
       }
     });
-
     contents.push(title, h('ul.layouts-group-list-items', groupItems));
 
     return contents;

--- a/javascripts/discourse/widgets/layouts-groups.js.es6
+++ b/javascripts/discourse/widgets/layouts-groups.js.es6
@@ -81,11 +81,7 @@ createWidget('layouts-group-link', {
   },
 
   click() {
-    if (group.is_group_user && group.has_messages) {
       DiscourseURL.routeTo(`/g/${this.attrs.name}/messages`);
-    } else {
-      DiscourseURL.routeTo(`/g/${this.attrs.name}`);
-    }
   },
 });
 

--- a/javascripts/discourse/widgets/layouts-groups.js.es6
+++ b/javascripts/discourse/widgets/layouts-groups.js.es6
@@ -1,4 +1,5 @@
 import { iconNode } from 'discourse-common/lib/icon-library';
+import { ajax } from 'discourse/lib/ajax';
 import DiscourseURL from 'discourse/lib/url';
 import { createWidget } from 'discourse/widgets/widget';
 import { h } from 'virtual-dom';
@@ -44,13 +45,23 @@ export default layouts.createLayoutsWidget('group-list', {
 
     if (groups.length === 0) {
       return [
-        h('a.layouts-group-list-header', I18n.t(themePrefix('groups_widget.title'))),
-        h('p.layouts-no-public-groups', I18n.t(themePrefix('groups_widget.no_public')))
+        h(
+          'a.layouts-group-list-header',
+          I18n.t(themePrefix('groups_widget.title'))
+        ),
+        h(
+          'p.layouts-no-public-groups',
+          I18n.t(themePrefix('groups_widget.no_public'))
+        ),
       ];
     }
 
     groups.forEach((group) => {
       if (!hiddenGroups.includes(group.id.toString())) {
+        ajax(`/groups/${group.name}.json`).then((result) => {
+          const groupAttrs = result.group;
+          group.groupAttrs = groupAttrs;
+        });
         groupItems.push(this.attach('layouts-group-link', group));
       }
     });
@@ -81,8 +92,12 @@ createWidget('layouts-group-link', {
   },
 
   click() {
+    const { groupAttrs } = this.attrs;
+
+    if (groupAttrs.has_messages) {
       DiscourseURL.routeTo(`/g/${this.attrs.name}/messages`);
+    } else {
+      DiscourseURL.routeTo(`/g/${this.attrs.name}`);
+    }
   },
 });
-
-


### PR DESCRIPTION
This changes the Title link to '/g?type=my' and the group links to '/g/group-slug/messages'.

It DOES NOT include selectively linking to '/g/group-slug/messages' only when there are group messages.

I've tried this but it fails to make any links:
```
  click() {
    if (group.is_group_user && group.has_messages) {
      DiscourseURL.routeTo(`/g/${this.attrs.name}/messages`);
    } else {
      DiscourseURL.routeTo(`/g/${this.attrs.name}`);
    }
  },
```