### PR TITLE
FIX: Group links not working due to missing import

### DIFF
--- a/javascripts/discourse/widgets/layouts-group-link.js.es6
+++ b/javascripts/discourse/widgets/layouts-group-link.js.es6
@@ -1,5 +1,6 @@
 import { iconNode } from 'discourse-common/lib/icon-library';
 import { createWidget } from 'discourse/widgets/widget';
+import DiscourseURL from 'discourse/lib/url';
 import { h } from 'virtual-dom';
 
 createWidget('layouts-group-link', {

--- a/javascripts/discourse/widgets/layouts-group-link.js.es6
+++ b/javascripts/discourse/widgets/layouts-group-link.js.es6
@@ -1,6 +1,6 @@
 import { iconNode } from 'discourse-common/lib/icon-library';
 import { createWidget } from 'discourse/widgets/widget';
-import DiscourseURL from 'discourse/lib/url';
+import { DiscourseURL } from 'discourse/lib/url';
 import { h } from 'virtual-dom';
 
 createWidget('layouts-group-link', {

--- a/javascripts/discourse/widgets/layouts-group-link.js.es6
+++ b/javascripts/discourse/widgets/layouts-group-link.js.es6
@@ -1,6 +1,6 @@
 import { iconNode } from 'discourse-common/lib/icon-library';
 import { createWidget } from 'discourse/widgets/widget';
-import { DiscourseURL } from 'discourse/lib/url';
+import DiscourseURL from 'discourse/lib/url';
 import { h } from 'virtual-dom';
 
 createWidget('layouts-group-link', {


### PR DESCRIPTION
This adds in an import command from an earlier commit which is required for the links to work - which they do now.

I tried putting it in {} but this broke it again.