### PR TITLE
Route group link back to /g

### DIFF
--- a/javascripts/discourse/widgets/layouts-groups.js.es6
+++ b/javascripts/discourse/widgets/layouts-groups.js.es6
@@ -20,7 +20,7 @@ export default layouts.createLayoutsWidget('group-list', {
         'a.layouts-group-list-header',
         {
           attributes: {
-            href: '/g?type=my',
+            href: '/g',
             title: I18n.t(themePrefix('groups_widget.title')),
           },
         },


### PR DESCRIPTION
Users already see their 'My Groups' in effect via the widget, so having this go to /g actually increases the utility quite a bit.