### PR TITLE
FEATURE: Custom group link title setting

### DIFF
--- a/javascripts/discourse/widgets/layouts-groups.js.es6
+++ b/javascripts/discourse/widgets/layouts-groups.js.es6
@@ -20,7 +20,7 @@ export default layouts.createLayoutsWidget('group-list', {
         'a.layouts-group-list-header',
         {
           attributes: {
-            href: '/g?type=my',
+            href: settings.header_link,
             title: I18n.t(themePrefix('groups_widget.title')),
           },
         },

--- a/javascripts/discourse/widgets/layouts-groups.js.es6
+++ b/javascripts/discourse/widgets/layouts-groups.js.es6
@@ -15,22 +15,25 @@ try {
 
 export default layouts.createLayoutsWidget('group-list', {
   getWidgetHeader() {
-    if (settings.show_header) {
-      return h(
-        'a.layouts-group-list-header',
+    if (settings.header_link) {
+     return h(
+       'a.layouts-group-list-header',
         {
           attributes: {
             href: settings.header_link,
             title: I18n.t(themePrefix('groups_widget.title')),
           },
         },
-        I18n.t(themePrefix('groups_widget.title'))
+      I18n.t(themePrefix('groups_widget.title'))
       );
-    }
+   } else {
+     return h('h3.layouts-group-list-header', I18n.t(themePrefix('groups_widget.title')));
+   }
 
     return null;
   },
 
+  
   html(attrs) {
     const { groups } = attrs;
     const contents = [];

--- a/javascripts/discourse/widgets/layouts-groups.js.es6
+++ b/javascripts/discourse/widgets/layouts-groups.js.es6
@@ -27,14 +27,7 @@ export default layouts.createLayoutsWidget('group-list', {
       I18n.t(themePrefix('groups_widget.title'))
       );
      } else {
-     return h(
-       'a.layouts-group-list-header', 
-        {
-          attributes: {
-            title: I18n.t(themePrefix('groups_widget.title')),
-          },
-        },       
-        I18n.t(themePrefix('groups_widget.title')));
+     return h('h3.layouts-group-list-header', I18n.t(themePrefix('groups_widget.title')));
      }
     
     return null;

--- a/javascripts/discourse/widgets/layouts-groups.js.es6
+++ b/javascripts/discourse/widgets/layouts-groups.js.es6
@@ -20,7 +20,7 @@ export default layouts.createLayoutsWidget('group-list', {
         'a.layouts-group-list-header',
         {
           attributes: {
-            href: settings.header_link,
+            href: settings.header_link || '/g',
             title: I18n.t(themePrefix('groups_widget.title')),
           },
         },

--- a/javascripts/discourse/widgets/layouts-groups.js.es6
+++ b/javascripts/discourse/widgets/layouts-groups.js.es6
@@ -20,7 +20,7 @@ export default layouts.createLayoutsWidget('group-list', {
         'a.layouts-group-list-header',
         {
           attributes: {
-//            href: settings.header_link || '#',
+            href: settings.header_link,
             title: I18n.t(themePrefix('groups_widget.title')),
           },
         },

--- a/javascripts/discourse/widgets/layouts-groups.js.es6
+++ b/javascripts/discourse/widgets/layouts-groups.js.es6
@@ -20,7 +20,7 @@ export default layouts.createLayoutsWidget('group-list', {
         'a.layouts-group-list-header',
         {
           attributes: {
-            href: settings.header_link || '/g',
+            href: settings.header_link || '#',
             title: I18n.t(themePrefix('groups_widget.title')),
           },
         },

--- a/javascripts/discourse/widgets/layouts-groups.js.es6
+++ b/javascripts/discourse/widgets/layouts-groups.js.es6
@@ -20,7 +20,7 @@ export default layouts.createLayoutsWidget('group-list', {
         'a.layouts-group-list-header',
         {
           attributes: {
-            href: settings.header_link || '#',
+//            href: settings.header_link || '#',
             title: I18n.t(themePrefix('groups_widget.title')),
           },
         },

--- a/javascripts/discourse/widgets/layouts-groups.js.es6
+++ b/javascripts/discourse/widgets/layouts-groups.js.es6
@@ -26,10 +26,17 @@ export default layouts.createLayoutsWidget('group-list', {
         },
       I18n.t(themePrefix('groups_widget.title'))
       );
-   } else {
-     return h('h3.layouts-group-list-header', I18n.t(themePrefix('groups_widget.title')));
-   }
-
+     } else {
+     return h(
+       'a.layouts-group-list-header', 
+        {
+          attributes: {
+            title: I18n.t(themePrefix('groups_widget.title')),
+          },
+        },       
+        I18n.t(themePrefix('groups_widget.title')));
+     }
+    
     return null;
   },
 

--- a/scss/base.scss
+++ b/scss/base.scss
@@ -1,6 +1,6 @@
 .layouts-group-list {
   padding: 0.7rem 0;
-  a.layouts-group-list-header, {
+  a.layouts-group-list-header {
     transition: color 0.25s ease;
     color: var(--primary);
     margin-bottom: 0.25rem;
@@ -16,12 +16,12 @@
       color: var(--primary-low-mid);
     }
   }
-  
+
   h3.layouts-group-list-header {
     margin-bottom: 0.25rem;
     padding: 0.5rem 1rem;
   }
-    
+
   &-items {
     list-style: none;
     margin: 0;

--- a/scss/base.scss
+++ b/scss/base.scss
@@ -1,6 +1,6 @@
 .layouts-group-list {
   padding: 0.7rem 0;
-  a.layouts-group-list-header {
+  layouts-group-list-header {
     transition: color 0.25s ease;
     color: var(--primary);
     margin-bottom: 0.25rem;

--- a/scss/base.scss
+++ b/scss/base.scss
@@ -1,6 +1,6 @@
 .layouts-group-list {
   padding: 0.7rem 0;
-  layouts-group-list-header {
+  a.layouts-group-list-header, h3.layouts-group-list-header {
     transition: color 0.25s ease;
     color: var(--primary);
     margin-bottom: 0.25rem;

--- a/scss/base.scss
+++ b/scss/base.scss
@@ -1,6 +1,6 @@
 .layouts-group-list {
   padding: 0.7rem 0;
-  a.layouts-group-list-header, h3.layouts-group-list-header {
+  a.layouts-group-list-header, {
     transition: color 0.25s ease;
     color: var(--primary);
     margin-bottom: 0.25rem;
@@ -16,7 +16,12 @@
       color: var(--primary-low-mid);
     }
   }
-
+  
+  h3.layouts-group-list-header {
+    margin-bottom: 0.25rem;
+    padding: 0.5rem 1rem;
+  }
+    
   &-items {
     list-style: none;
     margin: 0;

--- a/settings.yml
+++ b/settings.yml
@@ -4,6 +4,12 @@ show_header:
   description:
     en: 'Toggle the title header in the widget'
 
+header_link:
+  default: /g
+  type: string
+  description:
+    en: 'Where the header links to.'
+
 hidden_groups:
   type: list
   list_type: group


### PR DESCRIPTION
Adds a setting for routing the Groups link.

Remaining issue is that when it is Null, you get a link back to the current page instead.

I tried to put some conditionality in there so there is no href attribute when there is no link, but I couldn't manage it.