### PR TITLE
DEV: Hide trust level and auto groups by default

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -7,7 +7,7 @@ show_header:
 hidden_groups:
   type: list
   list_type: group
-  default: ''
+  default: trust_level_0|trust_level_1|trust_level_2|trust_level_3|trust_level_4|staff|everyone
   description:
     en: 'Select which groups should be hidden from the widget'
 

--- a/settings.yml
+++ b/settings.yml
@@ -7,7 +7,7 @@ show_header:
 hidden_groups:
   type: list
   list_type: group
-  default: trust_level_0|trust_level_1|trust_level_2|trust_level_3|trust_level_4|staff|everyone
+  default: 10|11|12|13|14|3|0
   description:
     en: 'Select which groups should be hidden from the widget'
 


### PR DESCRIPTION
Adds defaults to hidden_groups - these are groups that aren't usually helpful to have on the widget (especially for admins).